### PR TITLE
Add support for Boost.Unordered and Boost.Uuid

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -636,6 +636,13 @@ BOOST_DEFUN([Unordered],
 [BOOST_FIND_HEADER([boost/unordered_map.hpp])])
 
 
+# BOOST_UUID()
+# ------------
+# Look for Boost.Uuid
+BOOST_DEFUN([Uuid],
+[BOOST_FIND_HEADER([boost/uuid/uuid.hpp])])
+
+
 # BOOST_PROGRAM_OPTIONS([PREFERRED-RT-OPT])
 # -----------------------------------------
 # Look for Boost.Program_options.  For the documentation of PREFERRED-RT-OPT,


### PR DESCRIPTION
Hej hej!

These two commits add support for the header-only Boost library Unordered and Uuid.

Cheers
  Sven
