### PR TITLE
Fix for Mac OS X

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -403,7 +403,7 @@ dnl generated only once above (before we start the for loops).
       LDFLAGS=$boost_save_LDFLAGS
       LIBS=$boost_save_LIBS
       if test x"$Boost_lib" = xyes; then
-        Boost_lib_LDFLAGS="-L$boost_ldpath -Wl,-R$boost_ldpath"
+        Boost_lib_LDFLAGS="-L$boost_ldpath -Wl,-rpath $boost_ldpath"
         Boost_lib_LDPATH="$boost_ldpath"
         break 6
       else


### PR DESCRIPTION
This fixes an error in the resulting configure script when running on Mac OS X.  -Wl,-R isn't a valid param on the ld that comes with OS X.  Replacing with -rpath resolve this.
