### PR TITLE
Adding support for cross-compiling on Windows

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -851,8 +851,20 @@ LDFLAGS="$LDFLAGS $BOOST_SYSTEM_LDFLAGS"
 #   is not turned on. Please set the correct command line options for
 #   threading: -pthread (Linux), -pthreads (Solaris) or -mthreads (Mingw32)"
 CPPFLAGS="$CPPFLAGS $boost_cv_pthread_flag"
-BOOST_FIND_LIB([thread], [$1],
-               [boost/thread.hpp], [boost::thread t; boost::mutex m;])
+
+# When compiling for the Windows platform, the threads library is named
+# differently.
+case "$host_os" in
+  *mingw*)
+    BOOST_FIND_LIB([thread_win32], [$1],
+                   [boost/thread.hpp], [boost::thread t; boost::mutex m;])
+  ;;
+  *)
+    BOOST_FIND_LIB([thread], [$1],
+                   [boost/thread.hpp], [boost::thread t; boost::mutex m;])
+  ;;
+esac
+
 BOOST_THREAD_LIBS="$BOOST_THREAD_LIBS $BOOST_SYSTEM_LIBS $boost_cv_pthread_flag"
 BOOST_THREAD_LDFLAGS="$BOOST_SYSTEM_LDFLAGS"
 BOOST_CPPFLAGS="$BOOST_CPPFLAGS $boost_cv_pthread_flag"

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ BOOST_REQUIRE([1.34])
 dnl Then look for specific Boost libraries you need:
 BOOST_ARRAY
 BOOST_DATE_TIME
+BOOST_THREADS
 
 # Initialize the test suite.
 AC_CONFIG_TESTDIR([tests])


### PR DESCRIPTION
Hi Benoit - can you please merge this commit?  It allows the Boost threads library to be located when cross compiling for Windows (e.g. "./configure --host=i486-mingw32").  This is required as the Windows version of the Boost threads library has a different filename, so the existing test fails.
