### PR TITLE
Macro for detection of boost MPI.

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -684,6 +684,28 @@ BOOST_DEFUN([Math],
 [BOOST_FIND_HEADER([boost/math/special_functions.hpp])])
 
 
+# BOOST_MPI([PREFERRED-RT-OPT])
+# -------------------------------
+# Look for Boost MPI.  For the documentation of PREFERRED-RT-OPT, see the
+# documentation of BOOST_FIND_LIB above.  Uses MPICXX variable if it is
+# set, otherwise tries CXX
+# 
+BOOST_DEFUN([MPI],
+[
+  boost_save_CXX=${CXX}
+  boost_save_CXXCPP=${CXXCPP}
+  if test x"${MPICXX}" != x; then
+    CXX=${MPICXX}
+    CXXCPP="${MPICXX} -E"
+  fi
+  BOOST_FIND_LIB([mpi], [$1],
+                [boost/mpi.hpp],
+                [int argc = 0; char **argv = 0; boost::mpi::environment env(argc,argv);])
+  CXX=${boost_save_CXX}
+  CXXCPP=${boost_save_CXXCPP}
+])# BOOST_MPI
+
+
 # BOOST_MULTIARRAY()
 # ------------------
 # Look for Boost.MultiArray


### PR DESCRIPTION
This pull request adds a function for detecting boost MPI, which uses BOOST_FIND_LIB.  If the MPICXX variable is set (by ax_mpi.m4, acx_mpi.m4 or similar), then set the CXX and CXXCPP variables prior to the check and restore them afterwards.  Otherwise the standard CXX variable is used.  I have tested this on OS X with macports boost +openmpi variant, as well as on Ubuntu with self-installed boost.  Hopefully others find this useful...
