### PR TITLE
Perform sed and -mt code checks in C++ mode

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -206,6 +206,7 @@ AC_LANG_POP([C++])dnl
   AC_CACHE_CHECK([for Boost's header version],
     [boost_cv_lib_version],
     [m4_pattern_allow([^BOOST_LIB_VERSION$])dnl
+    AC_LANG_PUSH([C++])dnl
      _BOOST_SED_CPP([/^boost-lib-version = /{s///;s/\"//g;p;q;}],
                     [#include <boost/version.hpp>
 boost-lib-version = BOOST_LIB_VERSION],
@@ -217,6 +218,7 @@ boost-lib-version = BOOST_LIB_VERSION],
         AC_MSG_ERROR([invalid value: boost_major_version=$boost_major_version])
         ;;
     esac
+    AC_LANG_POP([C++])dnl
 fi
 CPPFLAGS=$boost_save_CPPFLAGS
 ])# BOOST_REQUIRE
@@ -1183,6 +1185,7 @@ fi])dnl end of AC_CACHE_CHECK
 # Thread) flavors of Boost.  Sets boost_guess_use_mt accordingly.
 AC_DEFUN([_BOOST_GUESS_WHETHER_TO_USE_MT],
 [# Check whether we do better use `mt' even though we weren't ask to.
+AC_LANG_PUSH([C++])dnl
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if defined _REENTRANT || defined _MT || defined __MT__
 /* use -mt */
@@ -1190,6 +1193,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 # error MT not needed
 #endif
 ]])], [boost_guess_use_mt=:], [boost_guess_use_mt=false])
+AC_LANG_POP([C++])dnl
 ])
 
 # _BOOST_AC_LINK_IFELSE(PROGRAM, [ACTION-IF-TRUE], [ACTION-IF-FALSE])


### PR DESCRIPTION
The default language is C, but since Boost is inherently a C++ library, it makes sense to invoke the C++ compiler for all Boost-related Autoconf tests, even if no C++ code is actually being compiled.

This change wraps the call to `_BOOST_SED_CPP` when detecting Boost's version, as well as the code for detecting the environment's multithreading status in `_BOOST_GUESS_WHETHER_TO_USE_MT`.

This has an added side effect, which is that when not using Libtool, there's no dependency on C at all — the `CC`, `CFLAGS`, and `CPP` macros don't affect the configure script. Technically, Boost.m4 depends on Libtool, but in my experience, the only thing it uses is the `$libext` variable, and then only when searching for a static library to link with. I can circumvent the full Libtool dependency by simply setting `$libext` directly (usually to `a`, but to `lib` on Windows compilers). This allows for faster configurations since we don't have to detect and test the capabilities of a C compiler that will never actually be used.

Even when Libtool _is_ used (as recommended), I think it's still better to perform the version and multithreading checks in C++ mode since they should really be testing C++ headers and C++ compiler settings, even when the analogous C values would most likely be the same.
