### PR TITLE
Fix POINTERCONTAINER -> POINTER_CONTAINER

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -964,7 +964,8 @@ BOOST_DEFUN([Variant],
 [BOOST_FIND_HEADER([boost/variant/variant_fwd.hpp])
 BOOST_FIND_HEADER([boost/variant.hpp])])
 
-# BOOST_POINTERCONTAINER()
+
+# BOOST_POINTER_CONTAINER()
 # ------------------------
 # Look for Boost.PointerContainer
 BOOST_DEFUN([Pointer_Container],
@@ -974,7 +975,8 @@ BOOST_FIND_HEADER([boost/ptr_container/ptr_vector.hpp])
 BOOST_FIND_HEADER([boost/ptr_container/ptr_array.hpp])
 BOOST_FIND_HEADER([boost/ptr_container/ptr_set.hpp])
 BOOST_FIND_HEADER([boost/ptr_container/ptr_map.hpp])
-])# BOOST_POINTERCONTAINER
+])# BOOST_POINTER_CONTAINER
+
 
 # BOOST_WAVE([PREFERRED-RT-OPT])
 # ------------------------------


### PR DESCRIPTION
The name used in the comments is not the name by which the macro can be called.
