### PR TITLE
should fix issues with missing linker AND issue with _win32 suffix, but ...

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -971,14 +971,24 @@ CPPFLAGS="$CPPFLAGS $boost_cv_pthread_flag"
 
 # When compiling for the Windows platform, the threads library is named
 # differently.
-case $host_os in
+#this suffix doesn't exist in new versions of boost, or possibly new 
+#versions of GCC on mingw I am assuming its boost's change for now 
+#and I am setting version to 1.48, for lack of knowledge as to when this 
+#change ocurred
+if test $boost_major_version -lt 148; then
+ case $host_os in
   (*mingw*) boost_thread_lib_ext=_win32;;
-esac
+ esac
+fi
 BOOST_FIND_LIBS([thread], [thread$boost_thread_lib_ext],
                 [$1],
                 [boost/thread.hpp], [boost::thread t; boost::mutex m;])
 
-BOOST_THREAD_LIBS="$BOOST_THREAD_LIBS $BOOST_SYSTEM_LIBS $boost_cv_pthread_flag"
+case $host_os in
+  (*mingw*) boost_thread_w32_socket_link=-lws2_32;;
+esac
+
+BOOST_THREAD_LIBS="$BOOST_THREAD_LIBS $BOOST_SYSTEM_LIBS $boost_cv_pthread_flag $boost_thread_w32_socket_link"
 BOOST_THREAD_LDFLAGS="$BOOST_SYSTEM_LDFLAGS"
 BOOST_CPPFLAGS="$BOOST_CPPFLAGS $boost_cv_pthread_flag"
 LIBS=$boost_thread_save_LIBS


### PR DESCRIPTION
...needs review as to cause and version # but it ought to do the job properly once we tie down exactly what version of boost made this change (or determine that its GCC's fault, and change the conditional)