### PR TITLE
Fix bug in BOOST_CHRONO macro.

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -574,7 +574,7 @@ BOOST_FIND_LIB([chrono], [$1],
                 [boost/chrono.hpp],
                 [boost::chrono::thread_clock d;])
 if test $enable_static_boost = yes && test $boost_major_version -ge 135; then
-  BOOST_FILESYSTEM_LIBS="$BOOST_FILESYSTEM_LIBS $BOOST_SYSTEM_LIBS"
+  BOOST_CHRONO_LIBS="$BOOST_CHRONO_LIBS $BOOST_SYSTEM_LIBS"
 fi
 LIBS=$boost_filesystem_save_LIBS
 LDFLAGS=$boost_filesystem_save_LDFLAGS


### PR DESCRIPTION
The current ``BOOST_CHRONO`` macro has a mistaken reference to ``BOOST_FILESYSTEM_LIBS`` in it (probably a copy/paste error). This causes a warning to be thrown by autoconf and may or may not cause ``--enable-static-boost`` to do the wrong thing.