### PR TITLE
BOOST_REQUIRE: use AC_DEFUN_ONCE to define MACRO

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -110,7 +110,7 @@ AC_LANG_POP([C++])dnl
 # On # success, defines HAVE_BOOST.  On failure, calls the optional
 # ACTION-IF-NOT-FOUND action if one was supplied.
 # Otherwise aborts with an error message.
-AC_DEFUN([BOOST_REQUIRE],
+AC_DEFUN_ONCE([BOOST_REQUIRE],
 [AC_REQUIRE([AC_PROG_CXX])dnl
 AC_REQUIRE([AC_PROG_GREP])dnl
 echo "$as_me: this is boost.m4[]_BOOST_SERIAL" >&AS_MESSAGE_LOG_FD


### PR DESCRIPTION
The commit message pretty much explains the problem.

I am not completely sure the reason for this nor if this is "the right fix", or even if there is no problem at all in `boost.m4`.

The issue (ours) is discussed here: https://github.com/bisdn/xdpd/issues/94

Pull-requesting in case it is the right fix and/or can help some.