### PR TITLE
boost.m4: recognize gcc 5.1 and 5.2

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -1296,6 +1296,10 @@ if test x$boost_cv_inc_path != xno; then
   # I'm not sure about my test for `il' (be careful: Intel's ICC pre-defines
   # the same defines as GCC's).
   for i in \
+    _BOOST_mingw_test(5, 2) \
+    _BOOST_gcc_test(5, 2) \
+    _BOOST_mingw_test(5, 1) \
+    _BOOST_gcc_test(5, 1) \
     _BOOST_mingw_test(5, 0) \
     _BOOST_gcc_test(5, 0) \
     _BOOST_mingw_test(4, 10) \


### PR DESCRIPTION
Add support for gcc 5.1 and 5.2 compilers