### PR TITLE
boost context API changed with 1.56; depends on threads with 1.57

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -584,27 +584,60 @@ LDFLAGS=$boost_filesystem_save_LDFLAGS
 # BOOST_CONTEXT([PREFERRED-RT-OPT])
 # -----------------------------------
 # Look for Boost.Context.  For the documentation of PREFERRED-RT-OPT, see the
-# documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
-# 1.51.0
+# documentation of BOOST_FIND_LIB above.
+#
+# * This library was introduced in Boost 1.51.0
+# * The signatures of make_fcontext() and jump_fcontext were changed in 1.56.0
+# * A dependency on boost_thread appears in 1.57.0
 BOOST_DEFUN([Context],
-[BOOST_FIND_LIB([context], [$1],
+[boost_context_save_LIBS=$LIBS
+ boost_context_save_LDFLAGS=$LDFLAGS
+if test $boost_major_version -ge 157; then
+  BOOST_THREAD([$1])
+  m4_pattern_allow([^BOOST_THREAD_(LIBS|LDFLAGS)$])dnl
+  LIBS="$LIBS $BOOST_THREAD_LIBS"
+  LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
+fi
+BOOST_FIND_LIB([context], [$1],
                 [boost/context/all.hpp],[[
+
 // creates a stack
 void * stack_pointer = new void*[4096];
 std::size_t const size = sizeof(void*[4096]);
 
 // context fc uses f() as context function
 // fcontext_t is placed on top of context stack
-// a pointer to fcontext_t is returned
+// a fcontext_t is returned
 fc = ctx::make_fcontext(stack_pointer, size, f);
-return ctx::jump_fcontext(&fcm, fc, 3) == 6;]],[dnl
+
+return ctx::jump_fcontext(&fcm, fc, 3) == 6;
+
+]],[dnl
 namespace ctx = boost::context;
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 105600
+
 // context
 static ctx::fcontext_t fcm, *fc;
+
 // context-function
 static void f(intptr_t i) {
     ctx::jump_fcontext(fc, &fcm, i * 2);
-}])
+}
+
+#else
+// context
+static ctx::fcontext_t fcm, fc;
+
+// context-function
+static void f(intptr_t i) {
+    ctx::jump_fcontext(&fc, fcm, i * 2);
+}
+#endif // older than BOOST 1.56.0
+])
+LIBS=$boost_context_save_LIBS
+LDFLAGS=$boost_context_save_LDFLAGS
 ])# BOOST_CONTEXT
 
 


### PR DESCRIPTION
BOOST_CONTEXT fails on Boost > 1.56 as the API has changed.  This PR updates the test code so that it works with the new API while retaining compatibility with the old.

I've copied the "dependency" code from BOOST_CHRONO to support the dependency on threads which appeared in 1.57.  Is there a better way of coding up dependencies?