### PR TITLE
Bring tests up-to-date with 1.51-1.59

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -690,8 +690,14 @@ LDFLAGS="$LDFLAGS $BOOST_CONTEXT_LDFLAGS"
 
 BOOST_FIND_LIB([coroutine], [$1],
                 [boost/coroutine/coroutine.hpp],
-                [boost::coroutines::coroutine< int(int) > coro; coro.empty();])
-
+                [
+#include <boost/version.hpp>
+#if   BOOST_VERSION <= 105500
+boost::coroutines::coroutine<int(int)> coro; coro.get();
+#else
+boost::coroutines::asymmetric_coroutine<int>::pull_type coro; coro.get();
+#endif
+])
 # Link-time dependency from coroutine to context, existed only in 1.53, in 1.54
 # coroutine doesn't use context from its headers but from its library.
 if test $boost_major_version -eq 153 || test $enable_static_boost = yes && test $boost_major_version -ge 154; then

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -688,16 +688,21 @@ m4_pattern_allow([^BOOST_(CONTEXT|SYSTEM)_(LIBS|LDFLAGS)])
 LIBS="$LIBS $BOOST_CONTEXT_LIBS $BOOST_SYSTEM_LIBS"
 LDFLAGS="$LDFLAGS $BOOST_CONTEXT_LDFLAGS"
 
-BOOST_FIND_LIB([coroutine], [$1],
-                [boost/coroutine/coroutine.hpp],
-                [
-#include <boost/version.hpp>
-#if   BOOST_VERSION <= 105500
-boost::coroutines::coroutine<int(int)> coro; coro.get();
-#else
-boost::coroutines::asymmetric_coroutine<int>::pull_type coro; coro.get();
-#endif
-])
+# in 1.53 coroutine was a header only library
+if test $boost_major_version -eq 153; then
+  BOOST_FIND_HEADER([boost/coroutine/coroutine.hpp])
+else
+  BOOST_FIND_LIB([coroutine], [$1],
+		  [boost/coroutine/coroutine.hpp],
+		  [
+  #include <boost/version.hpp>
+  #if   BOOST_VERSION <= 105500
+  boost::coroutines::coroutine<int(int)> coro; coro.get();
+  #else
+  boost::coroutines::asymmetric_coroutine<int>::pull_type coro; coro.get();
+  #endif
+  ])
+fi
 # Link-time dependency from coroutine to context, existed only in 1.53, in 1.54
 # coroutine doesn't use context from its headers but from its library.
 if test $boost_major_version -eq 153 || test $enable_static_boost = yes && test $boost_major_version -ge 154; then

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -814,8 +814,19 @@ BOOST_DEFUN([Geometry],
 # Look for Boost.Graphs.  For the documentation of PREFERRED-RT-OPT, see the
 # documentation of BOOST_FIND_LIB above.
 BOOST_DEFUN([Graph],
-[BOOST_FIND_LIB([graph], [$1],
+[boost_graph_save_LIBS=$LIBS
+boost_graph_save_LDFLAGS=$LDFLAGS
+# Link-time dependency from graph to regex was added as of 1.40.0.
+if test $boost_major_version -ge 140; then
+  BOOST_REGEX([$1])
+  m4_pattern_allow([^BOOST_REGEX_(LIBS|LDFLAGS)$])dnl
+  LIBS="$LIBS $BOOST_REGEX_LIBS"
+  LDFLAGS="$LDFLAGS $BOOST_REGEX_LDFLAGS"
+fi
+BOOST_FIND_LIB([graph], [$1],
                 [boost/graph/adjacency_list.hpp], [boost::adjacency_list<> g;])
+LIBS=$boost_graph_save_LIBS
+LDFLAGS=$boost_graph_save_LDFLAGS
 ])# BOOST_GRAPH
 
 

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -881,9 +881,19 @@ LDFLAGS=$boost_locale_save_LDFLAGS
 # Look for Boost.Log.  For the documentation of PREFERRED-RT-OPT, see the
 # documentation of BOOST_FIND_LIB above.
 BOOST_DEFUN([Log],
-[BOOST_FIND_LIB([log], [$1],
+[boost_log_save_LIBS=$LIBS
+boost_log_save_LDFLAGS=$LDFLAGS
+BOOST_SYSTEM([$1])
+BOOST_FILESYSTEM([$1])
+BOOST_DATE_TIME([$1])
+m4_pattern_allow([^BOOST_(SYSTEM|FILESYSTEM|DATE_TIME)_(LIBS|LDFLAGS)$])dnl
+LIBS="$LIBS $BOOST_DATE_TIME_LIBS $BOOST_FILESYSTEM_LIBS $BOOST_SYSTEM_LIBS"
+LDFLAGS="$LDFLAGS $BOOST_DATE_TIME_LDFLAGS $BOOST_FILESYSTEM_LDFLAGS $BOOST_SYSTEM_LDFLAGS"
+BOOST_FIND_LIB([log], [$1],
     [boost/log/core/core.hpp],
     [boost::log::attribute a; a.get_value();])
+LIBS=$boost_log_save_LIBS
+LDFLAGS=$boost_log_save_LDFLAGS
 ])# BOOST_LOG
 
 

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -859,9 +859,21 @@ BOOST_DEFUN([Lambda],
 # --------------
 # Look for Boost.Locale
 BOOST_DEFUN([Locale],
-[BOOST_FIND_LIB([locale], [$1],
+[
+boost_locale_save_LIBS=$LIBS
+boost_locale_save_LDFLAGS=$LDFLAGS
+# require SYSTEM for boost-1.50.0 and up
+if test $boost_major_version -ge 150; then
+  BOOST_SYSTEM([$1])
+  m4_pattern_allow([^BOOST_SYSTEM_(LIBS|LDFLAGS)$])dnl
+  LIBS="$LIBS $BOOST_SYSTEM_LIBS"
+  LDFLAGS="$LDFLAGS $BOOST_SYSTEM_LDFLAGS"
+fi # end of the Boost.System check.
+BOOST_FIND_LIB([locale], [$1],
     [boost/locale.hpp],
     [[boost::locale::generator gen; std::locale::global(gen(""));]])
+LIBS=$boost_locale_save_LIBS
+LDFLAGS=$boost_locale_save_LDFLAGS
 ])# BOOST_LOCALE
 
 # BOOST_LOG([PREFERRED-RT-OPT])

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -902,10 +902,17 @@ LDFLAGS=$boost_log_save_LDFLAGS
 # Look for Boost.Log.  For the documentation of PREFERRED-RT-OPT, see the
 # documentation of BOOST_FIND_LIB above.
 BOOST_DEFUN([Log_Setup],
-[AC_REQUIRE([BOOST_LOG])dnl
+[boost_log_setup_save_LIBS=$LIBS
+boost_log_setup_save_LDFLAGS=$LDFLAGS
+BOOST_LOG([$1])
+m4_pattern_allow([^BOOST_LOG_(LIBS|LDFLAGS)$])dnl
+LIBS="$LIBS $BOOST_LOG_LIBS"
+LDFLAGS="$LDFLAGS $BOOST_LOG_LDFLAGS"
 BOOST_FIND_LIB([log_setup], [$1],
     [boost/log/utility/setup/from_settings.hpp],
     [boost::log::basic_settings<char> bs; bs.empty();])
+LIBS=$boost_log_setup_save_LIBS
+LDFLAGS=$boost_log_setup_save_LDFLAGS
 ])# BOOST_LOG_SETUP
 
 

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -584,27 +584,60 @@ LDFLAGS=$boost_filesystem_save_LDFLAGS
 # BOOST_CONTEXT([PREFERRED-RT-OPT])
 # -----------------------------------
 # Look for Boost.Context.  For the documentation of PREFERRED-RT-OPT, see the
-# documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
-# 1.51.0
+# documentation of BOOST_FIND_LIB above.
+#
+# * This library was introduced in Boost 1.51.0
+# * The signatures of make_fcontext() and jump_fcontext were changed in 1.56.0
+# * A dependency on boost_thread appears in 1.57.0
 BOOST_DEFUN([Context],
-[BOOST_FIND_LIB([context], [$1],
+[boost_context_save_LIBS=$LIBS
+ boost_context_save_LDFLAGS=$LDFLAGS
+if test $boost_major_version -ge 157; then
+  BOOST_THREAD([$1])
+  m4_pattern_allow([^BOOST_THREAD_(LIBS|LDFLAGS)$])dnl
+  LIBS="$LIBS $BOOST_THREAD_LIBS"
+  LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
+fi
+BOOST_FIND_LIB([context], [$1],
                 [boost/context/all.hpp],[[
+
 // creates a stack
 void * stack_pointer = new void*[4096];
 std::size_t const size = sizeof(void*[4096]);
 
 // context fc uses f() as context function
 // fcontext_t is placed on top of context stack
-// a pointer to fcontext_t is returned
+// a fcontext_t is returned
 fc = ctx::make_fcontext(stack_pointer, size, f);
-return ctx::jump_fcontext(&fcm, fc, 3) == 6;]],[dnl
+
+return ctx::jump_fcontext(&fcm, fc, 3) == 6;
+
+]],[dnl
 namespace ctx = boost::context;
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 105600
+
 // context
 static ctx::fcontext_t fcm, *fc;
+
 // context-function
 static void f(intptr_t i) {
     ctx::jump_fcontext(fc, &fcm, i * 2);
-}])
+}
+
+#else
+// context
+static ctx::fcontext_t fcm, fc;
+
+// context-function
+static void f(intptr_t i) {
+    ctx::jump_fcontext(&fc, fcm, i * 2);
+}
+#endif // older than BOOST 1.56.0
+])
+LIBS=$boost_context_save_LIBS
+LDFLAGS=$boost_context_save_LDFLAGS
 ])# BOOST_CONTEXT
 
 


### PR DESCRIPTION
I've created a set of branches 
   * [context](/djerius/boost.m4/tree/context)
   * [coroutine](/djerius/boost.m4/tree/coroutine)
   * [graph](/djerius/boost.m4/tree/graph)
   * [locale](/djerius/boost.m4/tree/locale)
   * [log](/djerius/boost.m4/tree/log)

which bring boost.m4 up-to-date with boost version 1.51 - 1.59.  This PR includes all of the changes from those branches.  I'd previously issued a PR just for context, but I've withdrawn that in favor of this one.

The result have been successfully tested against 1.51 - 1.59 on Debian 7, gcc 4.7.2, with boost compiled with its default parameters.  The only failures are for those boost modules which don't exist on the boost version tested.

If you prefer separate PR's for all of the modules, please let me know.

