### PR TITLE
Get rid of empty lines in expanded macros in _BOOST_SED_CP

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -86,9 +86,10 @@ dnl boost-lib-version =
 dnl # 2 "conftest.cc" 3
 dnl                    "1_56"
 dnl
-dnl So get rid of the # lines, and glue the remaining ones together.
+dnl So get rid of the # and empty lines, and glue the remaining ones together.
 (eval "$ac_cpp conftest.$ac_ext") 2>&AS_MESSAGE_LOG_FD |
   grep -v '#' |
+  grep -v '^[[[:space:]]]*$' |
   tr -d '\r' |
   tr -s '\n' ' ' |
   $SED -n -e "$1" >conftest.i 2>&1],


### PR DESCRIPTION
GCC 6.1.1 (20160510) on Fedora rawhide outputs an empty line
that results in a space at the beginning of the joined line,
making the ^boost-lib-version matching fail:
```
 # 1 "<stdin>"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 31 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 63 "/usr/include/stdc-predef.h" 3 4

 # 32 "<command-line>" 2
 # 1 "<stdin>"
 # 28 "<stdin>"
 # 1 "/usr/include/boost/version.hpp" 1 3 4
 # 29 "<stdin>" 2
 boost-lib-version =
 # 29 "<stdin>" 3 4
                    "1_60"
```
results in:
```
 boost-lib-version = "1_60"
```
Removing empty lines fix this issue.