### PR TITLE
boost.m4: improve error message

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -22,7 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 m4_define([_BOOST_SERIAL], [m4_translit([
-# serial 26
+# serial 27
 ], [#
 ], [])])
 
@@ -317,7 +317,7 @@ AC_REQUIRE([_BOOST_GUESS_WHETHER_TO_USE_MT])dnl
 if test x"$boost_cv_inc_path" = xno; then
   AC_MSG_NOTICE([Boost not available, not searching for the Boost $1 library])
 else
-dnl The else branch is huge and wasn't intended on purpose.
+dnl The else branch is huge and wasn't indented on purpose.
 AC_LANG_PUSH([C++])dnl
 AS_VAR_PUSHDEF([Boost_lib], [boost_cv_lib_$1])dnl
 AS_VAR_PUSHDEF([Boost_lib_LDFLAGS], [boost_cv_lib_$1_LDFLAGS])dnl
@@ -330,7 +330,7 @@ AC_CACHE_CHECK([for the Boost $1 library], [Boost_lib],
                [_BOOST_FIND_LIBS($@)])
 case $Boost_lib in #(
   (no) _AC_MSG_LOG_CONFTEST
-    AC_MSG_ERROR([cannot find the flags to link with Boost $1])
+    AC_MSG_ERROR([cannot find flags to link with the Boost $1 library (libboost-$1)])
     ;;
 esac
 AC_SUBST(AS_TR_CPP([BOOST_$1_LDFLAGS]), [$Boost_lib_LDFLAGS])dnl


### PR DESCRIPTION
On my project, I received the following problem report from Alexandre
Duret-Lutz.

>     checking for Boost headers version >= 1.49.0... yes
>     checking for Boost's header version... 1_62
>     checking for the toolset name used by Boost for g++... configure: WARNING: could not figure out which toolset name to use for g++
>     checking boost/system/error_code.hpp usability... yes
>     checking boost/system/error_code.hpp presence... yes
>     checking for boost/system/error_code.hpp... yes
>     checking for the Boost system library... no
>     configure: error: cannot find the flags to link with Boost system
> 
>   The above error had me very confused, as I was understanding it as
>   "unable to link with Boost" (i.e., "the Boost system" as a whole) and
>   therefore had no idea what package I needed to install in addition to
>   what I have.
> 
>   The diagnostic would be much clearer as `cannot ... link with libboost-system`.
> 

Actually, since some "libraries" of Boost have no library, they are
header-only, I think we should stick to "Boost $1" in error messages,
but this one could use some redundance.  I changed it from

  configure: error: cannot find the flags to link with Boost system

to

  configure: error: cannot find flags to link with the Boost system library (libboost-system)

* build-aux/boost.m4: Serial 27.
Improve error message.