### PR TITLE
Add Boost.Atomic

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -396,8 +396,8 @@ AC_DEFUN([_BOOST_FIND_LIBS],
     AC_MSG_ERROR([the libext variable is empty, did you invoke Libtool?])
   boost_save_ac_objext=$ac_objext
   # Generate the test file.
-  AC_LANG_CONFTEST([AC_LANG_PROGRAM([#include <$4>
-$6], [$5])])
+  AC_LANG_CONFTEST([AC_LANG_PROGRAM([$6
+#include <$4>], [$5])])
 dnl Optimization hacks: compiling C++ is slow, especially with Boost.  What
 dnl we're trying to do here is guess the right combination of link flags
 dnl (LIBS / LDFLAGS) to use a given library.  This can take several

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -556,6 +556,23 @@ BOOST_DEFUN([Assign],
 [BOOST_FIND_HEADER([boost/assign.hpp])])
 
 
+# BOOST_ATOMIC([PREFERRED-RT-OPT])
+# -------------------------------
+# Look for Boost.Atomic.  For the documentation of PREFERRED-RT-OPT, see the
+# documentation of BOOST_FIND_LIB above.
+BOOST_DEFUN([Atomic],
+[BOOST_FIND_LIB([atomic], [$1],
+                [boost/atomic.hpp],
+                [boost::atomic<int> a;],
+                [#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif])
+])# BOOST_ATOMIC
+
+
 # BOOST_BIND()
 # ------------
 # Look for Boost.Bind.


### PR DESCRIPTION
Part of the changes I did on boost.m4 in https://github.com/xoreos/xoreos but never got around creating pull requests for. Sorry.

This adds a simple test for Boost.Atomic. However, due to the way the Boost library (or at least several versions of them) don't include all necessary headers, and those need to be included before the boost header, the CXX-PROLOGUE parameter handling in BOOST_FIND_LIB is changed a bit.