### PR TITLE
Recognize gcc 6.3

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -1416,6 +1416,8 @@ if test x$boost_cv_inc_path != xno; then
   # I'm not sure about my test for `il' (be careful: Intel's ICC pre-defines
   # the same defines as GCC's).
   for i in \
+    _BOOST_mingw_test(6, 3) \
+    _BOOST_gcc_test(6, 3) \
     _BOOST_mingw_test(6, 2) \
     _BOOST_gcc_test(6, 2) \
     _BOOST_mingw_test(6, 1) \


### PR DESCRIPTION
This change simple adds gcc 6.3 checks.

In xoreos, I also merged the mingw check into the gcc check (see https://github.com/xoreos/xoreos/blob/master/m4/boost.m4#L1397). I'm not sure if that's something you'd do as well, but if you would, feel free to copy-paste the change from xoreos.