### PR TITLE
m4/boost.m4: fix rpath option check for static linking

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -480,7 +480,7 @@ dnl generated only once above (before we start the for loops).
            *)
             for boost_cv_rpath_link_ldflag in -Wl,-R, -Wl,-rpath,; do
               LDFLAGS="$boost_save_LDFLAGS -L$boost_ldpath $boost_cv_rpath_link_ldflag$boost_ldpath"
-              LIBS="$boost_save_LIBS $Boost_lib_LIBS"
+              LIBS="$Boost_lib_LIBS $boost_save_LIBS"
               _BOOST_AC_LINK_IFELSE([],
                 [boost_rpath_link_ldflag_found=yes
                 break],


### PR DESCRIPTION
When statically linking, the order in which -l options are passed is
important. The contents of the LIBS option passed to the configure
environment should be passed *after* other -l options used internally
by the package.

For example, libboost_program_options may used symbols from the
libatomic library, and in this case, one need to pass LIBS="-latomic"
to cc-tool's configure script. When using dynamic linking, this works
fine, because the rpath test does "-latomic
-lboost_program_options". However, when statically linking, this
doesn't work because libboost_program_options uses symbols from
libatomic, so -latomic must be passed *after* -lboost_program_options.

Therefore, this commit inverts the list of variables used to construct
LIBS before doing the _BOOST_AC_LINK_IFELSE() test detecting the rpath
option to be used. Indeed, $boost_save_LIBS contains the previously
saved LIBS variable, and should be passed after $Boost_lib_LIBS.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>