### PR TITLE
Add missing GCC releases

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -1416,12 +1416,34 @@ if test x$boost_cv_inc_path != xno; then
   # I'm not sure about my test for `il' (be careful: Intel's ICC pre-defines
   # the same defines as GCC's).
   for i in \
+    _BOOST_mingw_test(8, 2) \
+    _BOOST_gcc_test(8, 2) \
+    _BOOST_mingw_test(8, 1) \
+    _BOOST_gcc_test(8, 1) \
+    _BOOST_mingw_test(8, 0) \
+    _BOOST_gcc_test(8, 0) \
+    _BOOST_mingw_test(7, 3) \
+    _BOOST_gcc_test(7, 3) \
+    _BOOST_mingw_test(7, 2) \
+    _BOOST_gcc_test(7, 2) \
+    _BOOST_mingw_test(7, 1) \
+    _BOOST_gcc_test(7, 1) \
+    _BOOST_mingw_test(7, 0) \
+    _BOOST_gcc_test(7, 0) \
+    _BOOST_mingw_test(6, 4) \
+    _BOOST_gcc_test(6, 4) \
+    _BOOST_mingw_test(6, 3) \
+    _BOOST_gcc_test(6, 3) \
     _BOOST_mingw_test(6, 2) \
     _BOOST_gcc_test(6, 2) \
     _BOOST_mingw_test(6, 1) \
     _BOOST_gcc_test(6, 1) \
     _BOOST_mingw_test(6, 0) \
     _BOOST_gcc_test(6, 0) \
+    _BOOST_mingw_test(5, 5) \
+    _BOOST_gcc_test(5, 5) \
+    _BOOST_mingw_test(5, 4) \
+    _BOOST_gcc_test(5, 4) \
     _BOOST_mingw_test(5, 3) \
     _BOOST_gcc_test(5, 3) \
     _BOOST_mingw_test(5, 2) \


### PR DESCRIPTION
Took releases from https://gcc.gnu.org/releases.html

Thanks to @Habbie and @DrMcCoy for contributing similar patches.

Closes #100 
Closes #96