### PR TITLE
Fix unit test detection after #94

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -396,8 +396,9 @@ AC_DEFUN([_BOOST_FIND_LIBS],
     AC_MSG_ERROR([the libext variable is empty, did you invoke Libtool?])
   boost_save_ac_objext=$ac_objext
   # Generate the test file.
-  AC_LANG_CONFTEST([AC_LANG_PROGRAM([$6
-#include <$4>], [$5])])
+  AC_LANG_CONFTEST([AC_LANG_PROGRAM([$7
+#include <$4>
+$6], [$5])])
 dnl Optimization hacks: compiling C++ is slow, especially with Boost.  What
 dnl we're trying to do here is guess the right combination of link flags
 dnl (LIBS / LDFLAGS) to use a given library.  This can take several
@@ -582,6 +583,7 @@ BOOST_DEFUN([Atomic],
 [BOOST_FIND_LIB([atomic], [$1],
                 [boost/atomic.hpp],
                 [boost::atomic<int> a;],
+                [ ],
                 [#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
This switches the order of vars in `AC_DEFUN([_BOOST_FIND_LIBS],` around again, needs some tests