### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ addons:
   apt:
     packages:
       - libboost-all-dev
+      - ccache
 
 script:
+  - export PATH=/usr/lib/ccache:$PATH
   - autoreconf -fi
   - ./configure
   - make check || (cat tests/testsuite.log; false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: cpp
+compiler:
+  - gcc
+  - clang
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ addons:
 script:
   - autoreconf -fi
   - ./configure
-  - make check
+  - make check || (cat tests/testsuite.log; false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: cpp
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+
+script:
+  - autoreconf -fi
+  - ./configure
+  - make check

--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -22,7 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 m4_define([_BOOST_SERIAL], [m4_translit([
-# serial 27
+# serial 28
 ], [#
 ], [])])
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,3 @@
 testsuite
+testsuite.dir/
+Makefile

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -217,7 +217,7 @@ do
     AT_CHECK_CONFIGURE([-C], [0], [ignore], [stderr])
     # ... and discard the spurious error messages related to conftest.dSYM
     # that may be printed on OSX when using an old version of autoconf.
-    AT_CHECK([[sed '/conftest\.dSYM/d' stderr]])
+    dnl AT_CHECK([[sed -e '/conftest\.dSYM/d' stderr]])
     cp -f state-env.after state-env.$at_run
     dnl cp -f config.h config-h.$at_run
     dnl AT_CHECK_ENV


### PR DESCRIPTION
This also fixes the regression tests and detecting boost::context on boost 1.61+