### PR TITLE
Fix ERROR_ON_UNUSABLE in Context for older version

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -787,7 +787,7 @@ static void f(intptr_t i) {
     ctx::jump_fcontext(&fc, fcm, i * 2);
 }
 #endif
-], [], [], [$2])
+], [], [$2])
 
 fi
 


### PR DESCRIPTION
31d73e5d introduced extra parameter, but this made the test
broken in older Boost versions where the extra parameter
was already used correctly.