### PR TITLE
Fix autoreconf issue with BOOST_SYSTEM

### DIFF
--- a/build-aux/boost.m4
+++ b/build-aux/boost.m4
@@ -1335,7 +1335,6 @@ BOOST_DEFUN([String_Algo],
 # 1.35.0 and is header only since 1.70.
 BOOST_DEFUN([System],
 [
-+[
 if test $boost_major_version -ge 170; then
   BOOST_FIND_HEADER([boost/system/error_code.hpp])
 else


### PR DESCRIPTION
This fixes the following error:
 
>   /usr/bin/m4:m4/boost.m4:1337: ERROR: end of file in string
>   autom4te: error: /usr/bin/m4 failed with exit status: 1
>   aclocal: error: /usr/bin/autom4te failed with exit status: 1
>   autoreconf: error: aclocal failed with exit status: 1
>   error: autoreconf failed

I'm not an expert on m4, but that line appears to be a leftover from a diff output?